### PR TITLE
fix(server): send x-opencode-directory: nvim-cwd on every request

### DIFF
--- a/lua/opencode/server/init.lua
+++ b/lua/opencode/server/init.lua
@@ -98,6 +98,16 @@ function Server:curl(path, method, body, on_success, on_error, opts)
     "-N",
   }
 
+  -- Route the request to the TUI whose working directory matches Neovim's.
+  -- In single-TUI / integrated-mode setups this matches the only TUI trivially.
+  -- In multi-TUI setups (`opencode serve` + several `opencode attach --dir ...`)
+  -- this ensures `tui.*` events are delivered to the intended TUI.
+  local nvim_cwd = vim.fn.getcwd()
+  if nvim_cwd and nvim_cwd ~= "" then
+    table.insert(command, "-H")
+    table.insert(command, "x-opencode-directory: " .. nvim_cwd)
+  end
+
   if opts.max_time then
     table.insert(command, "--max-time")
     table.insert(command, tostring(opts.max_time))

--- a/lua/opencode/server/init.lua
+++ b/lua/opencode/server/init.lua
@@ -137,6 +137,16 @@ function Server:curl(path, method, body, on_success, on_error, opts)
     table.insert(cmd, 2)
   end
 
+  -- Route the request to the TUI whose working directory matches Neovim's.
+  -- In single-TUI / integrated-mode setups this matches the only TUI trivially.
+  -- In multi-TUI setups (`opencode serve` + several `opencode attach --dir ...`)
+  -- this ensures `tui.*` events are delivered to the intended TUI.
+  local nvim_cwd = vim.fn.getcwd()
+  if nvim_cwd and nvim_cwd ~= "" then
+    table.insert(cmd, "-H")
+    table.insert(cmd, "x-opencode-directory: " .. nvim_cwd)
+  end
+
   if body then
     table.insert(cmd, "-d")
     table.insert(cmd, vim.fn.json_encode(body))


### PR DESCRIPTION
## Tasks

- [x] I read [CONTRIBUTING.md](https://github.com/nickjvandyke/opencode.nvim/blob/main/CONTRIBUTING.md)
- [x] I filled out this PR template
- [x] I reviewed AI-generated code myself
- [x] I made sure my changes pass automated checks
- [x] I responded to and/or resolved automated PR comments

## Description

### The bug

In setups where Neovim talks to a shared `opencode serve` that also has one or more `opencode attach --dir <path>` TUIs, `<leader>oq` / `opencode.prompt` / `opencode.ask` / the `tui.command.execute` commands appear to succeed (HTTP 200, no errors) but the prompt never appears in any TUI.

It's silent: no error, no notification, no visible effect.

### Root cause

The opencode TUI's event subscription filters events by the request's _instance directory_:

```ts
// packages/opencode/src/cli/cmd/tui/context/event.ts (~line 28, v1.4.11)
if (event.directory === project.instance.directory()) {
  handler(event.payload)
}
```

Each HTTP request to the opencode server establishes an Instance scope via either the `x-opencode-directory` header or a `?directory=` query parameter. `tui.*` events published by that request inherit the instance directory.

Previously, `Server:curl` in this plugin didn't send that header. As a result, every `tui.prompt.append` event carried the server's ambient cwd, which doesn't match any attach-TUI's `--dir`. The TUI subscriptions filtered the events out → silent no-op.

### The fix

Add `x-opencode-directory: <nvim cwd>` to every HTTP request in `Server:curl`.

### Compatibility

- **Single-TUI / integrated-mode setups (most users today):** no behavior change. The only TUI is the one nvim launches; its `--dir` is Neovim's cwd; the header matches trivially.
- **Multi-TUI setups (`opencode serve` + `opencode attach`):** previously broken, now correct.
- **Zero config changes required.** The fix is automatic.

### Testing

End-to-end reproduction on a real multi-TUI setup (opencode v1.4.11):

1. `opencode serve --port 4096` in the background.
2. `opencode attach http://127.0.0.1:4096 --dir ~/` in tmux pane A.
3. `opencode attach http://127.0.0.1:4096 --dir ~/somewhere` in tmux pane B.
4. Open Neovim in `~/somewhere`. Config: `vim.g.opencode_opts = { server = { port = 4096, start = false } }`.
5. Fire `:lua require("opencode").prompt("marker text")`.

> Note: `~/somewhere` must exist otherwise opencode will not start

**Before this PR:** HTTP 200 from `/tui/publish`, server log shows `type=tui.prompt.append publishing`, neither TUI shows anything.

**After this PR:** TUI A's prompt input shows `marker text`. TUI B is untouched.

## Related Issue(s)

Partially addresses #190. That issue asks for a way to make the plugin work with `opencode serve` + remote `opencode attach` setups, and captures the maintainer's concern: _"that'd require us to use a different (and more difficult) API entirely to send directly to the server. It also re-introduces the problem that we can't know the 'active' session, and have to best-guess it as the most recently interacted one."_

This PR resolves that concern without introducing any new API and without having to guess the active session: nvim's `getcwd()` is a natural, deterministic disambiguator that opencode's server already honors. It keeps the plugin's current TUI-based design intact (prompts still land in the TUI's input box; the user can still edit/resubmit) — the only thing that changes is that the right TUI receives them.

Not a complete solution to #190 on its own (there's also the discussion of remote hosts, password auth, message persistence, etc.), but it unblocks the core multi-TUI local case and should compose cleanly with whatever remote-server solution eventually lands.
