### PR TITLE
fix: send interrupt command immediately

### DIFF
--- a/lua/opencode/api/command.lua
+++ b/lua/opencode/api/command.lua
@@ -26,6 +26,10 @@ local M = {}
 function M.command(command)
   return require("opencode.server").get():next(function(server) ---@param server opencode.server.Server
     server:tui_execute_command(command)
+    -- opencode v1.0 prompts for a second interrupt; keep the Neovim command single-action.
+    if command == "session.interrupt" then
+      server:tui_execute_command(command)
+    end
   end)
 end
 


### PR DESCRIPTION
## Summary
- send `session.interrupt` twice from the Neovim command wrapper so one user action interrupts opencode v1.0 responses
- keep all other commands unchanged

Fixes #257

## Checks
- `luac -p lua/opencode/api/command.lua`
- `git diff --check`