### PR TITLE
Disable release-please job on fork repositories

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   release-please:
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v5


### PR DESCRIPTION
## Tasks

<!--
  I am happy to provide feedback and iterate together!
  Please complete these tasks to make it easier for both of us.
  Note that the automated checks and review run _after_ you open the PR.
-->

- [x] I read [CONTRIBUTING.md](https://github.com/nickjvandyke/opencode.nvim/blob/main/CONTRIBUTING.md)
- [ ] I reviewed AI-generated code myself
- [x] I addressed any automated check failures
- [ ] I addressed AI review feedback (if any)

## Description

Pushing in forked repositories triggers the `release-please` job. This PR aims to disable it on that scenario.

## Testing

<!-- Describe how to verify that your changes work as expected. -->

1. 
2. 
3. 

## Related Issue(s)

<!-- If this PR fixes any issues, please link them here. -->

## Screenshots/Videos

<!-- Add screenshots or videos of the changes if applicable. -->

<img width="1511" height="563" alt="image" src="https://github.com/user-attachments/assets/c1833a39-ef92-465e-b15b-8d28062ac121" />
