### PR TITLE
feat(terminal): add focus_on_open option

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Run local `opencode`s however you like and `opencode.nvim` will find them! Or po
 > [!IMPORTANT]
 > You _must_ run `opencode` with the `--port` flag to expose its server.
 
-If `opencode.nvim` can't find an existing `opencode`, it starts one for you via `vim.g.opencode_opts.server.start`, defaulting to an embedded terminal.
+If `opencode.nvim` can't find an existing `opencode`, it starts one for you via `vim.g.opencode_opts.server.start`, defaulting to an embedded terminal. Pass `focus_on_open = true` to keep focus after opening.
 
 #### Custom
 

--- a/lua/opencode/terminal.lua
+++ b/lua/opencode/terminal.lua
@@ -1,6 +1,7 @@
 local M = {}
 
 ---@class opencode.terminal.Opts : vim.api.keyset.win_config
+---@field focus_on_open? boolean Keep focus in the terminal window after opening instead of returning to the previous window.
 
 local winid
 local bufnr
@@ -19,8 +20,15 @@ function M.toggle(cmd, opts)
     winid = nil
   elseif bufnr ~= nil and vim.api.nvim_buf_is_valid(bufnr) then
     local previous_win = vim.api.nvim_get_current_win()
+    local focus_on_open = opts.focus_on_open
+    opts.focus_on_open = nil
     winid = vim.api.nvim_open_win(bufnr, true, opts)
-    vim.api.nvim_set_current_win(previous_win)
+    opts.focus_on_open = focus_on_open
+    if focus_on_open then
+      vim.cmd("startinsert")
+    else
+      vim.api.nvim_set_current_win(previous_win)
+    end
   else
     M.open(cmd, opts)
   end
@@ -40,7 +48,10 @@ function M.open(cmd, opts)
 
   local previous_win = vim.api.nvim_get_current_win()
   bufnr = vim.api.nvim_create_buf(false, false)
+  local focus_on_open = opts.focus_on_open
+  opts.focus_on_open = nil
   winid = vim.api.nvim_open_win(bufnr, true, opts)
+  opts.focus_on_open = focus_on_open
 
   vim.api.nvim_create_autocmd("ExitPre", {
     once = true,
@@ -65,7 +76,10 @@ function M.open(cmd, opts)
         vim.api.nvim_del_autocmd(auid)
         vim.api.nvim_set_current_win(winid)
         -- Enter insert mode to trigger redraw, then exit and return to previous window.
-        vim.cmd([[startinsert | call feedkeys("\<C-\>\<C-n>\<C-w>p", "n")]])
+        vim.cmd("startinsert")
+        if not opts.focus_on_open then
+          vim.cmd([[call feedkeys("\<C-\>\<C-n>\<C-w>p", "n")]])
+        end
       end
     end,
   })
@@ -77,7 +91,9 @@ function M.open(cmd, opts)
     end,
   })
 
-  vim.api.nvim_set_current_win(previous_win)
+  if not opts.focus_on_open then
+    vim.api.nvim_set_current_win(previous_win)
+  end
 end
 
 function M.close()


### PR DESCRIPTION
## Tasks                                                                                  
                                                                                               
 - [x] I read [CONTRIBUTING.md](https://github.com/nickjvandyke/opencode.nvim/blob/main/   
 CONTRIBUTING.md)                                                                          
 - [x] I ensured my changes pass automated checks                                          
 - [x] I reviewed and understand the AI-generated code in my changes (if any)              
 - [x] I addressed actionable AI review feedback (if any)                                  
                                                                                           
 ## Description                                                                            
                                                                                           
 By default `opencode.terminal.open()` and `toggle()` return focus to the                  
 previous window after opening. This adds a `focus_on_open` option that,                   
 when `true`, keeps the cursor in the terminal and enters insert mode.                     
 Affects three code paths: new terminal creation, re-showing a hidden                      
 terminal, and the `TermRequest` redraw autocmd.                                           
                                                                                           
 Fallback behavior is unchanged — omitting the option (or setting it                       
 `false`/`nil`) preserves exactly the existing focus behavior.                             
                                                                                           
 ## Testing                                                                                
                                                                                           
 1. Set up `vim.g.opencode_opts` with `focus_on_open = true` in both                       
    `server.start` and `server.toggle`, and map `require("opencode").toggle()`.            
 2. Press the toggle keymap — verify the terminal opens with focus and                     
    is in insert mode (ready for input).                                                   
 3. Press the toggle keymap again — verify the terminal hides.                             
 4. Press the toggle keymap a third time — verify it re-shows with focus                   
    and insert mode.                                                                       
 5. Remove `focus_on_open = true` and repeat — verify focus returns to                     
    the previous window (original behavior unchanged).                                     
                                                                                           
 ## Related Issue(s)                                                                       
                                                                                           
 N/A                                                                                       
                                                                                           
 ## Screenshots/Videos                                                                     
                                                                                           
 N/A                                                                                       