### PR TITLE
fix(terminal): no-focus loss during initial `ask()`

### DIFF
--- a/lua/opencode.lua
+++ b/lua/opencode.lua
@@ -88,28 +88,31 @@ M.operator = require("opencode.api.operator").operator
 ----------------
 
 ---Toggle the configured `opencode` server.
+---@return Promise?
 M.toggle = function()
   local opts = require("opencode.config").opts
   if opts.server and opts.server.toggle then
-    opts.server.toggle()
+    return opts.server.toggle()
   else
     vim.notify("No `opts.server.toggle` function configured", vim.log.levels.ERROR, { title = "opencode" })
   end
 end
 ---Start the configured `opencode` server.
+---@return Promise?
 M.start = function()
   local opts = require("opencode.config").opts
   if opts.server and opts.server.start then
-    opts.server.start()
+    return opts.server.start()
   else
     vim.notify("No `opts.server.start` function configured", vim.log.levels.ERROR, { title = "opencode" })
   end
 end
 ---Stop the configured `opencode` server.
+---@return Promise?
 M.stop = function()
   local opts = require("opencode.config").opts
   if opts.server and opts.server.stop then
-    opts.server.stop()
+    return opts.server.stop()
   else
     vim.notify("No `opts.server.stop` function configured", vim.log.levels.ERROR, { title = "opencode" })
   end

--- a/lua/opencode/config.lua
+++ b/lua/opencode/config.lua
@@ -40,7 +40,7 @@ local defaults = {
     username = vim.env.OPENCODE_SERVER_USERNAME or "opencode", -- Same env vars and defaults as `opencode`
     password = vim.env.OPENCODE_SERVER_PASSWORD,
     start = function()
-      require("opencode.terminal").open("opencode --port", {
+      return require("opencode.terminal").open("opencode --port", {
         split = "right",
         width = math.floor(vim.o.columns * 0.35),
       })
@@ -49,7 +49,7 @@ local defaults = {
       require("opencode.terminal").close()
     end,
     toggle = function()
-      require("opencode.terminal").toggle("opencode --port", {
+      return require("opencode.terminal").toggle("opencode --port", {
         split = "right",
         width = math.floor(vim.o.columns * 0.35),
       })

--- a/lua/opencode/promise/init.lua
+++ b/lua/opencode/promise/init.lua
@@ -46,10 +46,15 @@ Promise.__index = Promise
 
 local PromiseStatus = { Pending = "pending", Fulfilled = "fulfilled", Rejected = "rejected" }
 
+---Whether the given value is a `Promise`.
+---@param v any
+---@return boolean
 local is_promise = function(v)
   local tbl = getmetatable(v)
   return tbl ~= nil and tbl._is_promise == true
 end
+
+Promise.is_promise = is_promise
 
 local new_empty_userdata = function()
   return newproxy(true)

--- a/lua/opencode/server/discovery/init.lua
+++ b/lua/opencode/server/discovery/init.lua
@@ -106,6 +106,13 @@ function M.get()
         return Promise.reject("Failed to start `opencode`: " .. start_result)
       end
 
+      if Promise.is_promise(start_result) then
+        ---@cast start_result Promise
+        return start_result:next(function()
+          return poll()
+        end)
+      end
+
       return poll()
     end)
     :next(function(server) ---@param server opencode.server.Server

--- a/lua/opencode/server/init.lua
+++ b/lua/opencode/server/init.lua
@@ -16,11 +16,11 @@
 ---Called when when none are found; will retry after.
 ---May return a `Promise` that resolves when the server is ready;
 ---if so, server discovery polling waits for it.
----@field start? fun(): Promise?|false
+---@field start? (fun(): Promise?)|false
 ---
----@field stop? fun(): Promise?|false
+---@field stop? (fun(): Promise?)|false
 ---
----@field toggle? fun(): Promise?|false
+---@field toggle? (fun(): Promise?)|false
 
 ---An `opencode` server.
 ---@class opencode.server.Server

--- a/lua/opencode/server/init.lua
+++ b/lua/opencode/server/init.lua
@@ -14,11 +14,13 @@
 ---
 ---Start an `opencode` server.
 ---Called when when none are found; will retry after.
----@field start? fun()|false
+---May return a `Promise` that resolves when the server is ready;
+---if so, server discovery polling waits for it.
+---@field start? fun(): Promise?|false
 ---
----@field stop? fun()|false
+---@field stop? fun(): Promise?|false
 ---
----@field toggle? fun()|false
+---@field toggle? fun(): Promise?|false
 
 ---An `opencode` server.
 ---@class opencode.server.Server

--- a/lua/opencode/terminal.lua
+++ b/lua/opencode/terminal.lua
@@ -8,7 +8,10 @@ local bufnr
 ---Start if not running, else show/hide the window.
 ---@param cmd string
 ---@param opts? opencode.terminal.Opts
+---@return Promise
 function M.toggle(cmd, opts)
+  local Promise = require("opencode.promise")
+
   opts = opts or {
     split = "right",
     width = math.floor(vim.o.columns * 0.35),
@@ -17,67 +20,68 @@ function M.toggle(cmd, opts)
   if winid ~= nil and vim.api.nvim_win_is_valid(winid) then
     vim.api.nvim_win_hide(winid)
     winid = nil
+    return Promise.resolve()
   elseif bufnr ~= nil and vim.api.nvim_buf_is_valid(bufnr) then
-    local previous_win = vim.api.nvim_get_current_win()
-    winid = vim.api.nvim_open_win(bufnr, true, opts)
-    vim.api.nvim_set_current_win(previous_win)
+    winid = vim.api.nvim_open_win(bufnr, false, opts)
+    return Promise.resolve()
   else
-    M.open(cmd, opts)
+    return M.open(cmd, opts)
   end
 end
 
 ---@param cmd string
 ---@param opts? opencode.terminal.Opts
+---@return Promise
 function M.open(cmd, opts)
+  local Promise = require("opencode.promise")
+
   if bufnr ~= nil and vim.api.nvim_buf_is_valid(bufnr) then
-    return
+    return Promise.resolve()
   end
 
-  opts = opts or {
-    split = "right",
-    width = math.floor(vim.o.columns * 0.35),
-  }
+  return Promise.new(function(resolve)
+    opts = opts or {
+      split = "right",
+      width = math.floor(vim.o.columns * 0.35),
+    }
 
-  local previous_win = vim.api.nvim_get_current_win()
-  bufnr = vim.api.nvim_create_buf(false, false)
-  winid = vim.api.nvim_open_win(bufnr, true, opts)
+    bufnr = vim.api.nvim_create_buf(false, false)
+    winid = vim.api.nvim_open_win(bufnr, false, opts)
 
-  vim.api.nvim_create_autocmd("ExitPre", {
-    once = true,
-    callback = function()
-      -- Delete the buffer so session doesn't save + restore it.
-      -- Not worth the complexity to handle a restored terminal,
-      -- and this is consistent with most other Neovim terminal plugins.
-      M.close()
-    end,
-  })
+    vim.api.nvim_create_autocmd("ExitPre", {
+      once = true,
+      callback = function()
+        -- Delete the buffer so session doesn't save + restore it.
+        -- Not worth the complexity to handle a restored terminal,
+        -- and this is consistent with most other Neovim terminal plugins.
+        M.close()
+      end,
+    })
 
-  M.setup(winid)
+    M.setup(winid)
 
-  -- Redraw terminal buffer on initial render.
-  -- Fixes empty columns on the right side.
-  -- Only affects our implementation for some reason; I don't see this issue in `snacks.terminal`.
-  local auid
-  auid = vim.api.nvim_create_autocmd("TermRequest", {
-    buffer = bufnr,
-    callback = function(ev)
-      if ev.data.cursor[1] > 1 then
-        vim.api.nvim_del_autocmd(auid)
-        vim.api.nvim_set_current_win(winid)
-        -- Enter insert mode to trigger redraw, then exit and return to previous window.
-        vim.cmd([[startinsert | call feedkeys("\<C-\>\<C-n>\<C-w>p", "n")]])
-      end
-    end,
-  })
+    -- Wait for initial terminal render before resolving,
+    -- so that caller can be sure it's visible and ready for input.
+    local auid
+    auid = vim.api.nvim_create_autocmd("TermRequest", {
+      buffer = bufnr,
+      callback = function(ev)
+        if ev.data.cursor[1] > 1 then
+          vim.api.nvim_del_autocmd(auid)
+          resolve()
+        end
+      end,
+    })
 
-  vim.fn.jobstart(cmd, {
-    term = true,
-    on_exit = function()
-      M.close()
-    end,
-  })
-
-  vim.api.nvim_set_current_win(previous_win)
+    vim.api.nvim_buf_call(bufnr, function()
+      vim.fn.jobstart(cmd, {
+        term = true,
+        on_exit = function()
+          M.close()
+        end,
+      })
+    end)
+  end)
 end
 
 function M.close()

--- a/lua/opencode/terminal.lua
+++ b/lua/opencode/terminal.lua
@@ -38,9 +38,8 @@ function M.open(cmd, opts)
     width = math.floor(vim.o.columns * 0.35),
   }
 
-  local previous_win = vim.api.nvim_get_current_win()
   bufnr = vim.api.nvim_create_buf(false, false)
-  winid = vim.api.nvim_open_win(bufnr, true, opts)
+  winid = vim.api.nvim_open_win(bufnr, false, opts)
 
   vim.api.nvim_create_autocmd("ExitPre", {
     once = true,
@@ -54,30 +53,14 @@ function M.open(cmd, opts)
 
   M.setup(winid)
 
-  -- Redraw terminal buffer on initial render.
-  -- Fixes empty columns on the right side.
-  -- Only affects our implementation for some reason; I don't see this issue in `snacks.terminal`.
-  local auid
-  auid = vim.api.nvim_create_autocmd("TermRequest", {
-    buffer = bufnr,
-    callback = function(ev)
-      if ev.data.cursor[1] > 1 then
-        vim.api.nvim_del_autocmd(auid)
-        vim.api.nvim_set_current_win(winid)
-        -- Enter insert mode to trigger redraw, then exit and return to previous window.
-        vim.cmd([[startinsert | call feedkeys("\<C-\>\<C-n>\<C-w>p", "n")]])
-      end
-    end,
-  })
-
-  vim.fn.jobstart(cmd, {
-    term = true,
-    on_exit = function()
-      M.close()
-    end,
-  })
-
-  vim.api.nvim_set_current_win(previous_win)
+  vim.api.nvim_buf_call(bufnr, function()
+    vim.fn.jobstart(cmd, {
+      term = true,
+      on_exit = function()
+        M.close()
+      end,
+    })
+  end)
 end
 
 function M.close()


### PR DESCRIPTION
## Tasks

- [x] I read [CONTRIBUTING.md](https://github.com/nickjvandyke/opencode.nvim/blob/main/CONTRIBUTING.md)
- [x] I ensured my changes pass automated checks
- [x] I reviewed and understand the AI-generated code in my changes (if any)
- [x] I addressed actionable AI review feedback (if any)

## Description

The change allows for `opts.server.start|toggle|stop` (most importantly `start`) to return a promise, in which case the discovery will wait for the promise to resolve before polling.
This allows for the terminal implementation to "wait" until the initial frame of OpenCode is drawn.

AI disclaimer: Claude Opus 4.7 was used for codebase exploration, self-review and some fixups found in the review. All code not hand-written by me has been reviewed by me.

## Testing

1. Have a `snacks` free / native Neovim setup with opencode.nvim installed.
2. Execute `ask()` with a keybind.
3. The `vim.ui.input` prompt should only show up once the initial frame of OpenCode was drawn.
4. Enter a message or dismiss the prompt.
5. Ensure `toggle()` still functions as expected using a keybind.

(The change also shouldn't break the `snacks` experience...)

## Related Issue(s)

#274 

## Screenshots/Videos

https://github.com/user-attachments/assets/cf395ca7-9307-4c5a-9c45-397b2710f87a

These are the steps I took in the video:
1. `ask()` for a fresh server start and then exit.
2. `toggle()` for a fresh server start and then exit.
3. `ask()` for a fresh server start and send message.
4. `toggle()` to hide OpenCode.
5. `ask()` to send a message to OpenCode while hidden.
6. `toggle()` to show OpenCode again.

