### PR TITLE
fix: send interrupt command twice

### DIFF
--- a/lua/opencode/api/command.lua
+++ b/lua/opencode/api/command.lua
@@ -25,6 +25,13 @@ local M = {}
 ---@param server opencode.server.Server
 ---@return Promise
 function M.command(command, server)
+  if command == "session.interrupt" then
+    -- opencode v1 requires a second interrupt, mirroring the TUI's Esc confirmation.
+    return server:tui_execute_command(command):next(function()
+      return server:tui_execute_command(command)
+    end)
+  end
+
   return server:tui_execute_command(command)
 end
 


### PR DESCRIPTION
## Summary

Fixes #257.

`session.interrupt` now sends a second interrupt command so a single selection from opencode.nvim interrupts the current opencode response. Other commands still send once.

## Testing

- `git diff --check`
- Not run: Neovim/opencode runtime smoke, StyLua, and Lua/LuaLS checks are unavailable in this local environment.
