### PR TITLE
fix(server): preserve self binding in heartbeat timer disconnect

### DIFF
--- a/lua/opencode/server/init.lua
+++ b/lua/opencode/server/init.lua
@@ -337,7 +337,13 @@ function Server:connect()
     self.subscription_job_id = self:sse_subscribe(
       function(response)
         if self.heartbeat_timer then
-          self.heartbeat_timer:start(OPENCODE_HEARTBEAT_INTERVAL_MS + 1000, 0, vim.schedule_wrap(self.disconnect))
+          self.heartbeat_timer:start(
+            OPENCODE_HEARTBEAT_INTERVAL_MS + 1000,
+            0,
+            vim.schedule_wrap(function()
+              self:disconnect()
+            end)
+          )
         end
 
         if response.type == "server.connected" then


### PR DESCRIPTION
## Tasks

- [x] I read [CONTRIBUTING.md](https://github.com/nickjvandyke/opencode.nvim/blob/main/CONTRIBUTING.md)
- [x] I ensured my changes pass automated checks
- [x] I reviewed and understand the AI-generated code in my changes (if any)

## Description

Fixed a bug in `Server:connect()` where the heartbeat timer callback `self.disconnect` was passed as a bare function reference, losing the implicit `self` receiver. When the timer fired, it would attempt to call `disconnect()` without the correct `self` context, causing a runtime error.

## How to reproduce

1. Open nvim with opencode configured and start a session
2. Mock a server hang by suspending the server process: `pkill -STOP opencode`
3. Observe the error message — the heartbeat timer callback fails because `self` is nil
4. Resume the server afterward: `pkill -CONT opencode`

The fix wraps the callback in a closure to preserve the `self` binding:

```lua
-- Before
vim.schedule_wrap(self.disconnect)

-- After
vim.schedule_wrap(function()
  self:disconnect()
end)
```

## Testing

1. Verify that `:checkhealth opencode` passes
2. Connect to an opencode server and confirm the heartbeat timer fires without errors
3. Disconnect and reconnect to ensure no regressions in the connect/disconnect flow


## Related Issue(s)

## Screenshots/Videos

N/A
