### PR TITLE
feat(prompts): add commit prompt for conventional commit generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,7 @@ vim.o.autoread = true -- Required for `vim.g.opencode_opts.events.reload`
 vim.keymap.set({ "n", "x" }, "<leader>oa", function() require("opencode").ask("@this: ") end, { desc = "Ask OpenCode…" })
 vim.keymap.set({ "n", "x" }, "<leader>os", function() require("opencode").select() end,       { desc = "Select OpenCode…" })
 
-vim.keymap.set("n", "<leader>oc", function()
-  require("opencode").prompt(require("opencode.config").opts.select.prompts.commit)
-end,                                                                                                                                   { desc = "Generate conventional commit" })
+vim.keymap.set("n", "<leader>oc", function() require("opencode").prompt(require("opencode.config").opts.select.prompts.commit) end, { desc = "Generate conventional commit" })
 
 vim.keymap.set({ "n", "x" }, "go",  function() return require("opencode").operator("@this ") end,        { desc = "Append range to OpenCode", expr = true })
 vim.keymap.set("n",          "goo", function() return require("opencode").operator("@this ") .. "_" end, { desc = "Append line to OpenCode", expr = true })

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ vim.o.autoread = true -- Required for `vim.g.opencode_opts.events.reload`
 vim.keymap.set({ "n", "x" }, "<leader>oa", function() require("opencode").ask("@this: ") end, { desc = "Ask OpenCode…" })
 vim.keymap.set({ "n", "x" }, "<leader>os", function() require("opencode").select() end,       { desc = "Select OpenCode…" })
 
+vim.keymap.set("n", "<leader>oc", function()
+  require("opencode").prompt(require("opencode.config").opts.select.prompts.commit)
+end,                                                                                                                                   { desc = "Generate conventional commit" })
+
 vim.keymap.set({ "n", "x" }, "go",  function() return require("opencode").operator("@this ") end,        { desc = "Append range to OpenCode", expr = true })
 vim.keymap.set("n",          "goo", function() return require("opencode").operator("@this ") .. "_" end, { desc = "Append line to OpenCode", expr = true })
 
@@ -71,6 +75,10 @@ vim.keymap.set("n", "<S-C-d>", function() require("opencode").command("session.h
     -- Recommended/example keymaps
     vim.keymap.set({ "n", "x" }, "<leader>oa", function() require("opencode").ask("@this: ") end, { desc = "Ask OpenCode…" })
     vim.keymap.set({ "n", "x" }, "<leader>os", function() require("opencode").select() end,       { desc = "Select OpenCode…" })
+
+    vim.keymap.set("n", "<leader>oc", function()
+      require("opencode").prompt(require("opencode.config").opts.select.prompts.commit)
+    end,                                                                                                                                   { desc = "Generate conventional commit" })
 
     vim.keymap.set({ "n", "x" }, "go",  function() return require("opencode").operator("@this ") end,        { desc = "Append range to OpenCode", expr = true })
     vim.keymap.set("n",          "goo", function() return require("opencode").operator("@this ") .. "_" end, { desc = "Append line to OpenCode", expr = true })
@@ -202,16 +210,20 @@ opencode.nvim replaces placeholders in prompts with the corresponding context:
 
 Select prompts to review, explain, and improve your code:
 
-| Name          | Prompt                                           |
-| ------------- | ------------------------------------------------ |
-| `diagnostics` | Explain `@diagnostics`                           |
-| `document`    | Add comments documenting `@this`                 |
-| `explain`     | Explain `@this` and its context                  |
-| `fix`         | Fix `@diagnostics`                               |
-| `implement`   | Implement `@this`                                |
-| `optimize`    | Optimize `@this` for performance and readability |
-| `review`      | Review `@this` for correctness and readability   |
-| `test`        | Add tests for `@this`                            |
+| Name          | Prompt                                                              |
+| ------------- | ------------------------------------------------------------------- |
+| `commit`      | Generate a conventional commit message from staged changes          |
+| `diagnostics` | Explain `@diagnostics`                                              |
+| `document`    | Add comments documenting `@this`                                    |
+| `explain`     | Explain `@this` and its context                                     |
+| `fix`         | Fix `@diagnostics`                                                  |
+| `implement`   | Implement `@this`                                                   |
+| `optimize`    | Optimize `@this` for performance and readability                    |
+| `review`      | Review `@this` for correctness and readability                      |
+| `test`        | Add tests for `@this`                                               |
+
+> [!TIP]
+> After generating a commit message, copy it from the OpenCode TUI with `<leader>y` (press `ctrl+x` then `y`).
 
 ### Server
 

--- a/lua/opencode/config.lua
+++ b/lua/opencode/config.lua
@@ -70,6 +70,31 @@ local defaults = {
     prompt = "OpenCode: ",
     prompts = {
       ask = "...",
+      commit = [[Write a conventional commit message for the staged changes. Follow these steps:
+
+                1. Run `git status` to review changed files.
+                2. Run `git diff --cached` to inspect the staged changes.
+                3. Construct a commit message following the Conventional Commits specification.
+
+                Commit message structure:
+                - type: feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert
+                - scope: optional, recommended for clarity
+                - description: required, imperative mood (e.g. "add", not "added")
+                - body: optional, for additional context
+                - footer: optional, for breaking changes or issue references
+
+                Format: `<type>(<scope>): <description>` followed by optional body and footer.
+
+                Examples:
+                - feat(parser): add ability to parse arrays
+                - fix(ui): correct button alignment
+                - docs: update README with usage instructions
+                - refactor: improve performance of data processing
+                - chore: update dependencies
+                - feat!: send email on registration (BREAKING CHANGE: email service required)
+
+                Output only the commit message, do not commit.
+                Do not wrap the output in markdown code fences; respond with the raw commit message only.]],
       diagnostics = "Explain @diagnostics",
       document = "Add comments documenting @this",
       explain = "Explain @this and its context",


### PR DESCRIPTION
Add a `commit` prompt to the select prompts that generates conventional commit messages from staged `git diff` output. Include a `<leader>oc` keymap example and a tip for copying the result in the README.

## Tasks

- [x] I read [CONTRIBUTING.md](https://github.com/nickjvandyke/opencode.nvim/blob/main/CONTRIBUTING.md)
- [x] I ensured my changes pass automated checks
- [x] I reviewed and understand the AI-generated code in my changes (if any)

## Description

This PR introduces a new `commit` prompt to the selection menu that automatically generates conventional commit messages based on the staged `git diff` output. Generating commit messages is a very common and useful workflow in other AI assistants (like copilot.nvim), so adding this native capability will greatly enhance the developer experience in `opencode.nvim`. 

Additionally, I've updated the README to include an example keymap (`<leader>oc`) and a quick tip on how to copy the generated result.

## Testing

1. Stage some changes in the repository using `git add`.
2. Open the prompt menu (e.g., using `<leader>ox`).
3. Select the `commit` prompt from the list.
4. Verify that Opencode reads the staged diff and successfully generates a conventional commit message.
5. Copy the generated message using `C-x` `y`.